### PR TITLE
Removing random characters from the end of `parse` results (address Issue #4)

### DIFF
--- a/src/markdown.cc
+++ b/src/markdown.cc
@@ -7,6 +7,7 @@
 
 #include <v8.h>
 #include <node.h>
+#include <string.h>
 
 extern "C" {
   #include <mkdio.h>
@@ -22,7 +23,7 @@ using namespace node;
 static Handle<Value>
 Parse(const Arguments& args) {
   HandleScope scope;
-  char *buf;
+  char *res, buf [32768] = "";
   int len;
   if (args.Length() < 1 || !args[0]->IsString())
     return ThrowException(Exception::TypeError(String::New("String expected")));
@@ -31,8 +32,12 @@ Parse(const Arguments& args) {
   if ((doc = mkd_string(*in, in.length(), 0)) == 0)
     return ThrowException(Exception::Error(String::New("Failed to parse markdown")));
   if (mkd_compile(doc, 0))
-    len = mkd_document(doc, &buf);
+    len = mkd_document(doc, &res);
+  if (len != EOF) {
+    strncat(buf, res, len);
+  }
   Handle<String> md = String::New(buf);
+
   mkd_cleanup(doc);
   return scope.Close(md);
 }

--- a/test.js
+++ b/test.js
@@ -1,7 +1,10 @@
-
 var assert = require('assert'),
     fs = require('fs'),
-    markdown = require('./build/markdown')
+    markdown = require('./build/default/markdown');
 
-assert.ok(markdown.version.match(/^\d+\.\d+\.\d+$/), 'version is improperly formatted')
-assert.equal(fs.readFileSync('test/test.html'), markdown.parse(fs.readFileSync('test/test.md')))
+assert.ok(markdown.version.match(/^\d+\.\d+\.\d+$/), 'version is improperly formatted');
+
+for (var i = 0; i < 10; i++) {
+  assert.equal(fs.readFileSync('test/test.html').toString(), markdown.parse(fs.readFileSync('test/test.md').toString()));
+}
+

--- a/test/test.html
+++ b/test/test.html
@@ -3,6 +3,6 @@
 <h2>Articles</h2>
 
 <ul>
-<li>a</li>
-<li>b</li>
+<li><a href="/articles/article-a">Article A</a></li>
+<li><a href="/articles/article-b">Article B</a></li>
 </ul>

--- a/test/test.md
+++ b/test/test.md
@@ -1,7 +1,9 @@
-
 # Welcome
 
 ## Articles
 
-* a
-* b
+  * [Article A][a]
+  * [Article B][b]
+
+[a]: /articles/article-a
+[b]: /articles/article-b


### PR DESCRIPTION
Hi TJ,

I'm using your library for a small Express/CoffeeScript blog project, and I noticed that the output of `parse` would intermittently include extra characters on the end. To fix this, I dug through the source of RDiscount and found that writing the result of `mkd_document` to a new buffer using the explicit length returned fixes the issue.

In order to get the error to trigger, I had to increase the length of the test input and output docs and run the second test assertion in a for-loop. For some reason beyond me, the error only happens during the second iteration of the loop, and simply running the assertion twice doesn't cause it.

Hope you find this useful, and thanks for all your hard work building the Node ecosystem,
David Eisinger
david.eisinger@gmail.com
