### PR TITLE
submodule discount and statically link to it

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "deps/discount"]
 	path = deps/discount
 	url = git://github.com/Orc/discount.git
+[submodule "discount"]
+	path = discount
+	url = https://github.com/Orc/discount.git

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 , "version": "0.2.0"
 , "lib": "./build/default"
 , "main": "./build/default/markdown"
+, "scripts": { "preinstall": "node-waf configure build" }
 , "repository" : { "type" : "git"
                  , "url" : "http://github.com/visionmedia/node-discount.git"
                  }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
 , "version": "0.2.0"
 , "lib": "./build/default"
 , "main": "./build/default/markdown"
-, "scripts": { "preinstall": "node-waf configure build" }
 , "repository" : { "type" : "git"
                  , "url" : "http://github.com/visionmedia/node-discount.git"
                  }

--- a/wscript
+++ b/wscript
@@ -9,18 +9,13 @@ def configure(conf):
   conf.check_tool('compiler_cxx')
   conf.check_tool('node_addon')
   conf.check_cfg(atleast_pkgconfig_version='0.0.0', mandatory=True, errmsg='pkg-config was not found')
-  conf.check(
-    lib = 'markdown',
-    libpath = ['/usr/lib', '/usr/local/lib'],
-    uselib_store = 'DISCOUNT',
-    mandatory = True,
-    errmsg='markdown was not found (on homebrew this is "discount")'
-  )
 
 def build(bld):
+  bld.exec_command('cp -r ../discount/* .')
+  bld.exec_command('./configure.sh && make')
+
   obj = bld.new_task_gen('cxx', 'shlib', 'node_addon')
-  obj.linkflags = ["-lmarkdown", "-mimpure-text"]
+  obj.linkflags = ["-lmarkdown", "-mimpure-text", "-L."]
   obj.target = 'markdown'
   obj.source = 'src/markdown.cc'
-  obj.uselib = 'DISCOUNT'
-  obj.cxxflags = ["-fPIC"]
+  obj.cxxflags = ["-fPIC", "-I."]


### PR DESCRIPTION
This is mostly a work in progress. It does work as-is, but being that I don't know the waf api very well, it's pretty gross. Could use some feedback on it.

The idea is that anywhere Orc/discount builds, this should build w/o a dependency.

Should probably try for a shared/existing dependency first, then fallback to statically linking the submodule'd discount library in.
