### PR TITLE
Fix -fPIC issue and enable all discount features

### DIFF
--- a/wscript
+++ b/wscript
@@ -12,7 +12,7 @@ def configure(conf):
 
 def build(bld):
   bld.exec_command('cp -r ../discount/* .')
-  bld.exec_command('./configure.sh --with-dl=Both --enable-all-features && make')
+  bld.exec_command('./configure.sh --with-dl=Both --enable-all-features && make CFLAGS="-g -fPIC"')
 
   obj = bld.new_task_gen('cxx', 'shlib', 'node_addon')
   obj.linkflags = ["-lmarkdown", "-mimpure-text", "-L."]

--- a/wscript
+++ b/wscript
@@ -12,7 +12,7 @@ def configure(conf):
 
 def build(bld):
   bld.exec_command('cp -r ../discount/* .')
-  bld.exec_command('./configure.sh && make')
+  bld.exec_command('./configure.sh --with-dl=Both --enable-all-features && make')
 
   obj = bld.new_task_gen('cxx', 'shlib', 'node_addon')
   obj.linkflags = ["-lmarkdown", "-mimpure-text", "-L."]


### PR DESCRIPTION
a few oversights in last pull request. This fixes -fPIC on non-OSX systems (tested on ubuntu 10.04, 11.04 and whatever heroku/ec2 is running). also copied the configure flags from homebrew (--with-dl=Both --enable-all-features).
