### PR TITLE
Compatibility with node 0.6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
 , "tags": ["markdown", "md", "parser", "native"]
 , "author" : "TJ Holowaychuk <tj@vision-media.ca>"
 , "version": "0.2.2"
-, "lib": "./build/default"
-, "main": "./build/default/markdown"
+, "lib": "./build/Release"
+, "main": "./build/Release/markdown"
 , "scripts": { "preinstall": "node-waf configure build" }
 , "repository" : { "type" : "git"
                  , "url" : "http://github.com/visionmedia/node-discount.git"

--- a/wscript
+++ b/wscript
@@ -9,6 +9,7 @@ def configure(conf):
   conf.check_tool('compiler_cxx')
   conf.check_tool('node_addon')
   conf.check_cfg(atleast_pkgconfig_version='0.0.0', mandatory=True, errmsg='pkg-config was not found')
+  conf.env.set_variant('Release')
 
 def build(bld):
   bld.exec_command('cp -r ../discount/* .')


### PR DESCRIPTION
The current discount package is not compatible with node 0.6.x.
This happens because the new `node-waf` builds into `build/Release` instead of `build/default`.

I have update the package in a backwards-compatible way.
