### PR TITLE
Failed to build on arch linux

### DIFF
--- a/wscript
+++ b/wscript
@@ -2,6 +2,8 @@ srcdir = '.'
 blddir = 'build'
 VERSION = '0.0.1'
 
+import sys
+
 def set_options(opt):
   opt.tool_options('compiler_cxx')
 
@@ -16,7 +18,10 @@ def build(bld):
   bld.exec_command('./configure.sh --with-dl=Both --enable-all-features && make CFLAGS="-g -fPIC"')
 
   obj = bld.new_task_gen('cxx', 'shlib', 'node_addon')
-  obj.linkflags = ["-lmarkdown", "-mimpure-text", "-L."]
+  if sys.platform == 'linux2':
+    obj.linkflags = ["-lmarkdown", "-L."]
+  else:
+    obj.linkflags = ["-lmarkdown", "-mimpure-text", "-L."]
   obj.target = 'markdown'
   obj.source = 'src/markdown.cc'
   obj.cxxflags = ["-fPIC", "-I."]


### PR DESCRIPTION
Here is a small fix that made node-discount build on my machine.

Before this fix I was running into this error:

``` code
    cc -I. -L. -o echo tools/echo.c
    cc -I. -L. -o cols tools/cols.c
    [1/2] cxx: src/markdown.cc -> build/Release/src/markdown_1.o
    [2/2] cxx_link: build/Release/src/markdown_1.o -> build/Release/markdown.node
    g++: error: unrecognized command line option ‘-mimpure-text’
    Waf: Leaving directory `/home/alt/projects/skel/lib/node_modules/discount/build'
    Build failed:  -> task failed (err #1): 
            {task: cxx_link markdown_1.o -> markdown.node}
```
